### PR TITLE
remove confirm_full_exit, export validate for type validate

### DIFF
--- a/provider/src/rpc.rs
+++ b/provider/src/rpc.rs
@@ -118,11 +118,4 @@ pub trait ZkLinkRpc {
         eth_signature: Option<TxLayer1Signature>,
         submitter_signature: Option<ZkLinkSignature>,
     ) -> RpcResult<TxHash>;
-
-    #[method(name = "confirmFullExit")]
-    async fn confirm_full_exit(
-        &self,
-        tx_hash: TxHash,
-        submitter_signature: ZkLinkSignature,
-    ) -> RpcResult<bool>;
 }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -6,6 +6,8 @@ pub mod tx_type;
 pub mod utils;
 
 pub mod prelude {
+    pub use validator::Validate;
+
     pub use super::basic_types::{
         bit_convert::BitConvert,
         float_convert::FloatConversions,

--- a/types/src/tx_type/validator.rs
+++ b/types/src/tx_type/validator.rs
@@ -12,7 +12,7 @@ use crate::prelude::{
     SubAccountId, TokenId, ZkLinkAddress,
 };
 use num::BigUint;
-use validator::{Validate, ValidationError};
+pub use validator::{Validate, ValidationError};
 
 /// Check transaction account value validation
 ///


### PR DESCRIPTION
1. confirm_full_exit for internal use only, no exposure required